### PR TITLE
Optimize run to avoid quadratic map cloning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,8 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  test:
+    name: "Test"
     runs-on: ubuntu-latest
 
     strategy:
@@ -23,3 +24,21 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm test
+
+  lint:
+    name: "Lint"
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@types/mocha": "10.0.1",
         "@types/node": "18.11.18",
         "ecmarkup": "^3.1.1",
-        "mocha": "10.2.0"
+        "mocha": "10.2.0",
+        "typescript": "4.9.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3449,6 +3450,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/underscore": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
@@ -6286,6 +6300,12 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true
     },
     "underscore": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Async Context proposal for JavaScript",
   "scripts": {
     "build": "mkdir -p build && ecmarkup spec.html build/index.html",
+    "lint": "tsc -p tsconfig.json",
     "test": "mocha"
   },
   "repository": "legendecas/proposal-async-context",
@@ -26,6 +27,7 @@
     "@types/mocha": "10.0.1",
     "@types/node": "18.11.18",
     "ecmarkup": "^3.1.1",
-    "mocha": "10.2.0"
+    "mocha": "10.2.0",
+    "typescript": "4.9.4"
   }
 }

--- a/src/fork.ts
+++ b/src/fork.ts
@@ -10,9 +10,9 @@ import type { AsyncContext } from "./index";
  * mapping) as an OwnedFork would.
  */
 export class FrozenFork {
-  #mapping: Mapping | undefined;
+  #mapping: Mapping;
 
-  constructor(mapping: Mapping | undefined) {
+  constructor(mapping: Mapping) {
     this.#mapping = mapping;
   }
 
@@ -23,7 +23,7 @@ export class FrozenFork {
    * For FrozenFork, that's as simple as returning the known-frozen Mapping,
    * because we know it can't have been modified.
    */
-  join(_current: Mapping | undefined): Mapping | undefined {
+  join(_current: Mapping): Mapping {
     return this.#mapping;
   }
 }

--- a/src/fork.ts
+++ b/src/fork.ts
@@ -23,7 +23,7 @@ export class FrozenFork {
    * For FrozenFork, that's as simple as returning the known-frozen Mapping,
    * because we know it can't have been modified.
    */
-  join(): Mapping {
+  join(_current: Mapping): Mapping {
     return this.#mapping;
   }
 }
@@ -39,13 +39,11 @@ export class FrozenFork {
  * will clone the current state and we restore the clone to the prior state.
  */
 export class OwnedFork<T> {
-  #mapping: Mapping;
   #key: AsyncContext<T>;
   #has: boolean;
   #prev: T | undefined;
 
   constructor(mapping: Mapping, key: AsyncContext<T>) {
-    this.#mapping = mapping;
     this.#key = key;
     this.#has = mapping.has(key);
     this.#prev = mapping.get(key);
@@ -59,11 +57,11 @@ export class OwnedFork<T> {
    * reallocate if anyone has since taken a snapshot) in the hopes that we
    * won't need to reallocate.
    */
-  join(): Mapping {
+  join(current: Mapping): Mapping {
     if (this.#has) {
-      return this.#mapping.set(this.#key, this.#prev);
+      return current.set(this.#key, this.#prev);
     } else {
-      return this.#mapping.delete(this.#key);
+      return current.delete(this.#key);
     }
   }
 }

--- a/src/fork.ts
+++ b/src/fork.ts
@@ -2,14 +2,14 @@ import type { Mapping } from "./mapping";
 import type { AsyncContext } from "./index";
 
 /**
- * FrozenFork holds a frozen Mapping that will be simply restored when the fork is
- * rejoined.
+ * FrozenRevert holds a frozen Mapping that will be simply restored when the
+ * revert is run.
  *
  * This is used when we already know that the mapping is frozen, so that
- * rejoining will not attempt to mutate the Mapping (and allocate a new
- * mapping) as an OwnedFork would.
+ * reverting will not attempt to mutate the Mapping (and allocate a new
+ * mapping) as a Revert would.
  */
-export class FrozenFork {
+export class FrozenRevert {
   #mapping: Mapping;
 
   constructor(mapping: Mapping) {
@@ -17,28 +17,29 @@ export class FrozenFork {
   }
 
   /**
-   * The Storage container will call join when it wants to restore its current
-   * Mapping to the state at the start of the fork.
+   * The Storage container will call restore when it wants to revert its
+   * current Mapping to the state at the start of the fork.
    *
-   * For FrozenFork, that's as simple as returning the known-frozen Mapping,
+   * For FrozenRevert, that's as simple as returning the known-frozen Mapping,
    * because we know it can't have been modified.
    */
-  join(_current: Mapping): Mapping {
+  restore(_current: Mapping): Mapping {
     return this.#mapping;
   }
 }
 
 /**
- * OwnedFork holds an unfrozen Mapping that we will attempt to modify when
- * rejoining to attempt to restore it to its prior state.
+ * Revert holds the information on how to undo a modification to our Mappings,
+ * and will attempt to modify the current state when we attempt to restore it
+ * to its prior state.
  *
  * This is used when we know that the Mapping is unfrozen at start, because
- * it's possible that no one will snapshot this Mapping before we rejoin. In
- * that case, we can simply modify the Mapping (without cloning) to restore it
- * to its prior state. If someone does snapshot it, then modifying will clone
- * the current state and we restore the clone to the prior state.
+ * it's possible that no one will snapshot this Mapping before we restore. In
+ * that case, we can simply modify the Mapping without cloning. If someone did
+ * snapshot it, then modifying will clone the current state and we restore the
+ * clone to the prior state.
  */
-export class OwnedFork<T> {
+export class Revert<T> {
   #key: AsyncContext<T>;
   #has: boolean;
   #prev: T | undefined;
@@ -50,14 +51,14 @@ export class OwnedFork<T> {
   }
 
   /**
-   * The Storage container will call join when it wants to restore its current
-   * Mapping to the state at the start of the fork.
+   * The Storage container will call restore when it wants to revert its
+   * current Mapping to the state at the start of the fork.
    *
-   * For OwnedFork, we mutate the known-unfrozen-at-start mapping (which may
+   * For Revert, we mutate the known-unfrozen-at-start mapping (which may
    * reallocate if anyone has since taken a snapshot) in the hopes that we
    * won't need to reallocate.
    */
-  join(current: Mapping): Mapping {
+  restore(current: Mapping): Mapping {
     if (this.#has) {
       return current.set(this.#key, this.#prev);
     } else {

--- a/src/fork.ts
+++ b/src/fork.ts
@@ -1,5 +1,5 @@
-import type { Mapping } from './mapping';
-import type { AsyncContext } from './index';
+import type { Mapping } from "./mapping";
+import type { AsyncContext } from "./index";
 
 /**
  * FrozenFork holds a frozen Mapping that will be simply restored when the fork is

--- a/src/fork.ts
+++ b/src/fork.ts
@@ -10,9 +10,9 @@ import type { AsyncContext } from "./index";
  * mapping) as an OwnedFork would.
  */
 export class FrozenFork {
-  #mapping: Mapping;
+  #mapping: Mapping | undefined;
 
-  constructor(mapping: Mapping) {
+  constructor(mapping: Mapping | undefined) {
     this.#mapping = mapping;
   }
 
@@ -23,20 +23,20 @@ export class FrozenFork {
    * For FrozenFork, that's as simple as returning the known-frozen Mapping,
    * because we know it can't have been modified.
    */
-  join(_current: Mapping): Mapping {
+  join(_current: Mapping | undefined): Mapping | undefined {
     return this.#mapping;
   }
 }
 
 /**
- * OwnedFork holds an unfrozen Mapping that we will attempt when rejoining to
- * attempt to restore it to its prior state.
+ * OwnedFork holds an unfrozen Mapping that we will attempt to modify when
+ * rejoining to attempt to restore it to its prior state.
  *
  * This is used when we know that the Mapping is unfrozen at start, because
  * it's possible that no one will snapshot this Mapping before we rejoin. In
- * that case, we can simply modify the Mapping (without reallocation) to
- * restore it to its prior state. If someone does snapshot it, then modifying
- * will clone the current state and we restore the clone to the prior state.
+ * that case, we can simply modify the Mapping (without cloning) to restore it
+ * to its prior state. If someone does snapshot it, then modifying will clone
+ * the current state and we restore the clone to the prior state.
  */
 export class OwnedFork<T> {
   #key: AsyncContext<T>;

--- a/src/fork.ts
+++ b/src/fork.ts
@@ -1,0 +1,69 @@
+import type { Mapping } from './mapping';
+import type { AsyncContext } from './index';
+
+/**
+ * FrozenFork holds a frozen Mapping that will be simply restored when the fork is
+ * rejoined.
+ *
+ * This is used when we already know that the mapping is frozen, so that
+ * rejoining will not attempt to mutate the Mapping (and allocate a new
+ * mapping) as an OwnedFork would.
+ */
+export class FrozenFork {
+  #mapping: Mapping;
+
+  constructor(mapping: Mapping) {
+    this.#mapping = mapping;
+  }
+
+  /**
+   * The Storage container will call join when it wants to restore its current
+   * Mapping to the state at the start of the fork.
+   *
+   * For FrozenFork, that's as simple as returning the known-frozen Mapping,
+   * because we know it can't have been modified.
+   */
+  join(): Mapping {
+    return this.#mapping;
+  }
+}
+
+/**
+ * OwnedFork holds an unfrozen Mapping that we will attempt when rejoining to
+ * attempt to restore it to its prior state.
+ *
+ * This is used when we know that the Mapping is unfrozen at start, because
+ * it's possible that no one will snapshot this Mapping before we rejoin. In
+ * that case, we can simply modify the Mapping (without reallocation) to
+ * restore it to its prior state. If someone does snapshot it, then modifying
+ * will clone the current state and we restore the clone to the prior state.
+ */
+export class OwnedFork<T> {
+  #mapping: Mapping;
+  #key: AsyncContext<T>;
+  #has: boolean;
+  #prev: T | undefined;
+
+  constructor(mapping: Mapping, key: AsyncContext<T>) {
+    this.#mapping = mapping;
+    this.#key = key;
+    this.#has = mapping.has(key);
+    this.#prev = mapping.get(key);
+  }
+
+  /**
+   * The Storage container will call join when it wants to restore its current
+   * Mapping to the state at the start of the fork.
+   *
+   * For OwnedFork, we mutate the known-unfrozen-at-start mapping (which may
+   * reallocate if anyone has since taken a snapshot) in the hopes that we
+   * won't need to reallocate.
+   */
+  join(): Mapping {
+    if (this.#has) {
+      return this.#mapping.set(this.#key, this.#prev);
+    } else {
+      return this.#mapping.delete(this.#key);
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,45 +1,38 @@
-type AnyFunc = (...args: any) => any;
-type Storage = Map<AsyncContext<unknown>, unknown>;
+import { Storage } from "./storage";
 
-let __storage__: Storage = new Map();
+type AnyFunc<T> = (this: T, ...args: any) => any;
 
 export class AsyncContext<T> {
-  static wrap<F extends AnyFunc>(fn: F): F {
-    const current = __storage__;
+  static wrap<F extends AnyFunc<any>>(fn: F): F {
+    const snapshot = Storage.snapshot();
 
-    function wrap(...args: Parameters<F>): ReturnType<F> {
-      return run(fn, current, this, args);
-    };
+    function wrap(this: ThisType<F>, ...args: Parameters<F>): ReturnType<F> {
+      const fork = Storage.restore(snapshot);
+      try {
+        return fn.apply(this, args);
+      } finally {
+        Storage.join(fork);
+      }
+    }
 
     return wrap as unknown as F;
   }
 
-  run<F extends AnyFunc>(
+  run<F extends AnyFunc<null>>(
     value: T,
     fn: F,
     ...args: Parameters<F>
   ): ReturnType<F> {
-    const next = new Map(__storage__);
-    next.set(this, value);
-    return run(fn, next, null, args);
+    const fork = Storage.fork(this);
+    Storage.set(this, value);
+    try {
+      return fn.apply(null, args);
+    } finally {
+      Storage.join(fork);
+    }
   }
 
   get(): T {
-    return __storage__.get(this) as T;
-  }
-}
-
-function run<F extends AnyFunc>(
-  fn: F,
-  next: Storage,
-  binding: ThisType<F>,
-  args: Parameters<F>
-): ReturnType<F> {
-  const previous = __storage__;
-  try {
-    __storage__ = next;
-    return fn.apply(binding, args);
-  } finally {
-    __storage__ = previous;
+    return Storage.get(this);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,11 @@ export class AsyncContext<T> {
     const snapshot = Storage.snapshot();
 
     function wrap(this: ThisType<F>, ...args: Parameters<F>): ReturnType<F> {
-      const fork = Storage.restore(snapshot);
+      const head = Storage.switch(snapshot);
       try {
         return fn.apply(this, args);
       } finally {
-        Storage.join(fork);
+        Storage.restore(head);
       }
     }
 
@@ -23,12 +23,11 @@ export class AsyncContext<T> {
     fn: F,
     ...args: Parameters<F>
   ): ReturnType<F> {
-    const fork = Storage.fork(this);
-    Storage.set(this, value);
+    const revert = Storage.set(this, value);
     try {
       return fn.apply(null, args);
     } finally {
-      Storage.join(fork);
+      Storage.restore(revert);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export class AsyncContext<T> {
     }
   }
 
-  get(): T {
+  get(): T | undefined {
     return Storage.get(this);
   }
 }

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -5,25 +5,26 @@ import type { AsyncContext } from "./index";
  * taken of the current data.
  */
 export class Mapping {
+  #data: Map<AsyncContext<unknown>, unknown> | null;
+
   /**
    * If a snapshot of this data is taken, then further modifications cannot be
    * made directly. Instead, set/delete will clone this Mapping and modify
    * _that_ instance.
    */
-  #frozen = false;
+  #frozen: boolean;
 
-  #data: Map<AsyncContext<unknown>, unknown>;
-
-  constructor(data: Map<AsyncContext<unknown>, unknown>) {
+  constructor(data: Map<AsyncContext<unknown>, unknown> | null) {
     this.#data = data;
+    this.#frozen = data === null;
   }
 
   has<T>(key: AsyncContext<T>): boolean {
-    return this.#data.has(key);
+    return this.#data?.has(key) || false;
   }
 
   get<T>(key: AsyncContext<T>): T | undefined {
-    return this.#data.get(key) as T | undefined;
+    return this.#data?.get(key) as T | undefined;
   }
 
   /**
@@ -32,7 +33,7 @@ export class Mapping {
    */
   set<T>(key: AsyncContext<T>, value: T): Mapping {
     const mapping = this.#fork();
-    mapping.#data.set(key, value);
+    mapping.#data!.set(key, value);
     return mapping;
   }
 
@@ -42,7 +43,7 @@ export class Mapping {
    */
   delete<T>(key: AsyncContext<T>): Mapping {
     const mapping = this.#fork();
-    mapping.#data.delete(key);
+    mapping.#data!.delete(key);
     return mapping;
   }
 

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -1,0 +1,70 @@
+import type { AsyncContext } from "./index";
+
+/**
+ * Stores all AsyncContext data, and tracks whether any snapshots have been
+ * taken of the current data.
+ */
+export class Mapping {
+  /**
+   * If a snapshot of this data is taken, then further modifications cannot be
+   * made directly. Instead, set/delete will clone this Mapping and modify
+   * _that_ instance.
+   */
+  #frozen = false;
+
+  #data: Map<AsyncContext<unknown>, unknown>;
+
+  constructor(data: Map<AsyncContext<unknown>, unknown>) {
+    this.#data = data;
+  }
+
+  has<T>(key: AsyncContext<T>): boolean {
+    return this.#data.has(key);
+  }
+
+  get<T>(key: AsyncContext<T>): T {
+    return this.#data.get(key) as T;
+  }
+
+  /**
+   * Like the standard Map.p.set, except that we will allocate a new Mapping
+   * instance if this instance is frozen.
+   */
+  set<T>(key: AsyncContext<T>, value: T): Mapping {
+    const mapping = this.#fork();
+    mapping.#data.set(key, value);
+    return mapping;
+  }
+
+  /**
+   * Like the standard Map.p.delete, except that we will allocate a new Mapping
+   * instance if this instance is frozen.
+   */
+  delete<T>(key: AsyncContext<T>): Mapping {
+    const mapping = this.#fork();
+    mapping.#data.delete(key);
+    return mapping;
+  }
+
+  /**
+   * Prevents further modifications to this Mapping.
+   */
+  freeze(): void {
+    this.#frozen = true;
+  }
+
+  isFrozen() {
+    return this.#frozen;
+  }
+
+  /**
+   * We only need to fork if the Mapping is frozen (someone has a snapshot of
+   * the current data), else we can just modify our data directly.
+   */
+  #fork(): Mapping {
+    if (this.#frozen) {
+      return new Mapping(new Map(this.#data));
+    }
+    return this;
+  }
+}

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -22,8 +22,8 @@ export class Mapping {
     return this.#data.has(key);
   }
 
-  get<T>(key: AsyncContext<T>): T {
-    return this.#data.get(key) as T;
+  get<T>(key: AsyncContext<T>): T | undefined {
+    return this.#data.get(key) as T | undefined;
   }
 
   /**
@@ -53,7 +53,7 @@ export class Mapping {
     this.#frozen = true;
   }
 
-  isFrozen() {
+  isFrozen(): boolean {
     return this.#frozen;
   }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,78 @@
+import { Mapping } from "./mapping";
+import { FrozenFork, OwnedFork } from "./fork";
+import type { AsyncContext } from "./index";
+
+/**
+ * Storage is the (internal to the language) storage container of all
+ * AsyncContext data.
+ *
+ * None of the methods here are exposed to users, they're only exposed to the AsyncContext class.
+ */
+export class Storage {
+  static #current: Mapping = new Mapping(new Map());
+
+  /**
+   * Get retrieves the current value assigned to the AsyncContext.
+   */
+  static get<T>(key: AsyncContext<T>): T {
+    return this.#current.get(key);
+  }
+
+  /**
+   * Set assigns a new value to the AsyncContext.
+   */
+  static set<T>(key: AsyncContext<T>, value: T) {
+    // If the Mappings are frozen (someone has snapshot it), then modifying the
+    // mappings will return a clone containing the modification.
+    this.#current = this.#current.set(key, value);
+  }
+
+  /**
+   * Fork is called before modifying the global storage state (either by
+   * replacing the current mappings or assigning a new value to an individual
+   * AsyncContext).
+   *
+   * The Fork instance returned will be able to restore the mappings to the
+   * unmodified state.
+   */
+  static fork<T>(key: AsyncContext<T>): OwnedFork<T> | FrozenFork {
+    if (this.#current.isFrozen()) {
+      return new FrozenFork(this.#current);
+    }
+    return new OwnedFork(this.#current, key);
+  }
+
+  /**
+   * Join will restore the global storage state to state at the time of the
+   * fork.
+   */
+  static join<T>(fork: FrozenFork | OwnedFork<T>) {
+    this.#current = fork.join();
+  }
+
+  /**
+   * Snapshot freezes the current storage state, and returns a new fork which
+   * can restore the global storage state to the state at the time of the
+   * snapshot.
+   */
+  static snapshot(): FrozenFork {
+    this.#current.freeze();
+    return new FrozenFork(this.#current);
+  }
+
+  /**
+   * Restore restores the global storage state to the state at the time of the
+   * snapshot.
+   */
+  static restore(snapshot: FrozenFork): FrozenFork {
+    const previous = this.#current;
+    this.#current = snapshot.join();
+
+    // Technically, previous may not be frozen. But we know its state cannot
+    // change, because the only way to modify it is to restore it to the
+    // Storage container, and the only way to do that is to have snapshot it.
+    // So it's either snapshot (and frozen), or it's not and thus cannot be
+    // modified.
+    return new FrozenFork(previous);
+  }
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -21,7 +21,7 @@ export class Storage {
   /**
    * Set assigns a new value to the AsyncContext.
    */
-  static set<T>(key: AsyncContext<T>, value: T) {
+  static set<T>(key: AsyncContext<T>, value: T): void {
     const current = this.#current || new Mapping(new Map());
     // If the Mappings are frozen (someone has snapshot it), then modifying the
     // mappings will return a clone containing the modification.
@@ -48,7 +48,7 @@ export class Storage {
    * Join will restore the global storage state to state at the time of the
    * fork.
    */
-  static join<T>(fork: FrozenFork | OwnedFork<T>) {
+  static join<T>(fork: FrozenFork | OwnedFork<T>): void {
     // The only way for #current to be undefined at a join is if we're in the
     // we've snapshot the initial empty state with `wrap` and restored it. In
     // which case, we're operating on a FrozenFork, and the param doesn't

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -47,7 +47,7 @@ export class Storage {
    * fork.
    */
   static join<T>(fork: FrozenFork | OwnedFork<T>) {
-    this.#current = fork.join();
+    this.#current = fork.join(this.#current);
   }
 
   /**

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -57,7 +57,7 @@ export class Storage {
    * snapshot.
    */
   static snapshot(): FrozenFork {
-    this.#current?.freeze();
+    this.#current.freeze();
     return new FrozenFork(this.#current);
   }
 

--- a/tests/async-context.test.ts
+++ b/tests/async-context.test.ts
@@ -169,6 +169,209 @@ describe("sync", () => {
       assert.equal(b.get(), undefined);
     });
 
+    it("wrap within nesting different contexts, 2", () => {
+      const a = new AsyncContext<Value>();
+      const b = new AsyncContext<Value>();
+      const c = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+      const third = { id: 3 };
+
+      const wrap = a.run(first, () => {
+        const wrap = b.run(second, () => {
+          const wrap = c.run(third, () => {
+            debugger;
+            return AsyncContext.wrap(() => {
+              assert.equal(a.get(), first);
+              assert.equal(b.get(), second);
+              assert.equal(c.get(), third);
+            });
+          });
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), second);
+          assert.equal(c.get(), undefined);
+          return wrap;
+        });
+        assert.equal(a.get(), first);
+        assert.equal(b.get(), undefined);
+        assert.equal(c.get(), undefined);
+
+        return wrap;
+      });
+
+      assert.equal(a.get(), undefined);
+      assert.equal(b.get(), undefined);
+      assert.equal(c.get(), undefined);
+      wrap();
+      assert.equal(a.get(), undefined);
+      assert.equal(b.get(), undefined);
+      assert.equal(c.get(), undefined);
+    });
+
+    it("wrap within nesting different contexts, 3", () => {
+      const a = new AsyncContext<Value>();
+      const b = new AsyncContext<Value>();
+      const c = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+      const third = { id: 3 };
+
+      const wrap = a.run(first, () => {
+        const wrap = b.run(second, () => {
+          AsyncContext.wrap(() => {});
+
+          const wrap = c.run(third, () => {
+            debugger;
+            return AsyncContext.wrap(() => {
+              assert.equal(a.get(), first);
+              assert.equal(b.get(), second);
+              assert.equal(c.get(), third);
+            });
+          });
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), second);
+          assert.equal(c.get(), undefined);
+          return wrap;
+        });
+        assert.equal(a.get(), first);
+        assert.equal(b.get(), undefined);
+        assert.equal(c.get(), undefined);
+
+        return wrap;
+      });
+
+      assert.equal(a.get(), undefined);
+      assert.equal(b.get(), undefined);
+      assert.equal(c.get(), undefined);
+      wrap();
+      assert.equal(a.get(), undefined);
+      assert.equal(b.get(), undefined);
+      assert.equal(c.get(), undefined);
+    });
+
+    it("wrap within nesting different contexts, 4", () => {
+      const a = new AsyncContext<Value>();
+      const b = new AsyncContext<Value>();
+      const c = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+      const third = { id: 3 };
+
+      const wrap = a.run(first, () => {
+        AsyncContext.wrap(() => {});
+
+        const wrap = b.run(second, () => {
+          const wrap = c.run(third, () => {
+            debugger;
+            return AsyncContext.wrap(() => {
+              assert.equal(a.get(), first);
+              assert.equal(b.get(), second);
+              assert.equal(c.get(), third);
+            });
+          });
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), second);
+          assert.equal(c.get(), undefined);
+          return wrap;
+        });
+        assert.equal(a.get(), first);
+        assert.equal(b.get(), undefined);
+        assert.equal(c.get(), undefined);
+
+        return wrap;
+      });
+
+      assert.equal(a.get(), undefined);
+      assert.equal(b.get(), undefined);
+      assert.equal(c.get(), undefined);
+      wrap();
+      assert.equal(a.get(), undefined);
+      assert.equal(b.get(), undefined);
+      assert.equal(c.get(), undefined);
+    });
+
+    it("wrap within nesting different contexts, 5", () => {
+      const a = new AsyncContext<Value>();
+      const b = new AsyncContext<Value>();
+      const c = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+      const third = { id: 3 };
+
+      const wrap = a.run(first, () => {
+        const wrap = b.run(second, () => {
+          const wrap = c.run(third, () => {
+            return AsyncContext.wrap(() => {
+              assert.equal(a.get(), first);
+              assert.equal(b.get(), second);
+              assert.equal(c.get(), third);
+            });
+          });
+
+          AsyncContext.wrap(() => {});
+
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), second);
+          assert.equal(c.get(), undefined);
+          return wrap;
+        });
+        assert.equal(a.get(), first);
+        assert.equal(b.get(), undefined);
+        assert.equal(c.get(), undefined);
+
+        return wrap;
+      });
+
+      assert.equal(a.get(), undefined);
+      assert.equal(b.get(), undefined);
+      assert.equal(c.get(), undefined);
+      wrap();
+      assert.equal(a.get(), undefined);
+      assert.equal(b.get(), undefined);
+      assert.equal(c.get(), undefined);
+    });
+
+    it("wrap within nesting different contexts, 6", () => {
+      const a = new AsyncContext<Value>();
+      const b = new AsyncContext<Value>();
+      const c = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+      const third = { id: 3 };
+
+      const wrap = a.run(first, () => {
+        const wrap = b.run(second, () => {
+          const wrap = c.run(third, () => {
+            return AsyncContext.wrap(() => {
+              assert.equal(a.get(), first);
+              assert.equal(b.get(), second);
+              assert.equal(c.get(), third);
+            });
+          });
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), second);
+          assert.equal(c.get(), undefined);
+          return wrap;
+        });
+
+        AsyncContext.wrap(() => {});
+
+        assert.equal(a.get(), first);
+        assert.equal(b.get(), undefined);
+        assert.equal(c.get(), undefined);
+
+        return wrap;
+      });
+
+      assert.equal(a.get(), undefined);
+      assert.equal(b.get(), undefined);
+      assert.equal(c.get(), undefined);
+      wrap();
+      assert.equal(a.get(), undefined);
+      assert.equal(b.get(), undefined);
+      assert.equal(c.get(), undefined);
+    });
+
     it("wrap out of order", () => {
       const ctx = new AsyncContext<Value>();
       const first = { id: 1 };

--- a/tests/async-context.test.ts
+++ b/tests/async-context.test.ts
@@ -3,9 +3,34 @@ import { strict as assert } from "assert";
 
 type Value = { id: number };
 
+const _it = it;
+it = (() => {
+  throw new Error("use `test` function");
+}) as any;
+
+// Test both from the initial state, and from a run state.
+// This is because the initial state might be "frozen", and
+// that can cause different code paths.
+function test(name: string, fn: () => void) {
+  _it(name, () => {
+    fn();
+
+    // Ensure we're running from a new state, which won't be frozen.
+    const throwaway = new AsyncContext<null>();
+    throwaway.run(null, fn);
+
+    throwaway.run(null, () => {
+      AsyncContext.wrap(() => {});
+
+      // Ensure we're running from a new state, which is frozen.
+      fn();
+    });
+  });
+}
+
 describe("sync", () => {
   describe("run and get", () => {
-    it("has initial undefined state", () => {
+    test("has initial undefined state", () => {
       const ctx = new AsyncContext<Value>();
 
       const actual = ctx.get();
@@ -13,7 +38,7 @@ describe("sync", () => {
       assert.equal(actual, undefined);
     });
 
-    it("return value", () => {
+    test("return value", () => {
       const ctx = new AsyncContext<Value>();
       const expected = { id: 1 };
 
@@ -22,7 +47,7 @@ describe("sync", () => {
       assert.equal(actual, expected);
     });
 
-    it("get returns current context value", () => {
+    test("get returns current context value", () => {
       const ctx = new AsyncContext<Value>();
       const expected = { id: 1 };
 
@@ -31,7 +56,7 @@ describe("sync", () => {
       });
     });
 
-    it("get within nesting contexts", () => {
+    test("get within nesting contexts", () => {
       const ctx = new AsyncContext<Value>();
       const first = { id: 1 };
       const second = { id: 2 };
@@ -46,7 +71,7 @@ describe("sync", () => {
       assert.equal(ctx.get(), undefined);
     });
 
-    it("get within nesting different contexts", () => {
+    test("get within nesting different contexts", () => {
       const a = new AsyncContext<Value>();
       const b = new AsyncContext<Value>();
       const first = { id: 1 };
@@ -68,7 +93,7 @@ describe("sync", () => {
   });
 
   describe("wrap", () => {
-    it("stores initial undefined state", () => {
+    test("stores initial undefined state", () => {
       const ctx = new AsyncContext<Value>();
       const wrapped = AsyncContext.wrap(() => ctx.get());
 
@@ -77,7 +102,7 @@ describe("sync", () => {
       });
     });
 
-    it("stores current state", () => {
+    test("stores current state", () => {
       const ctx = new AsyncContext<Value>();
       const expected = { id: 1 };
 
@@ -92,35 +117,107 @@ describe("sync", () => {
       assert.equal(ctx.get(), undefined);
     });
 
-    it("runs within wrap", () => {
+    test("runs within wrap", () => {
       const ctx = new AsyncContext<Value>();
       const first = { id: 1 };
       const second = { id: 2 };
 
-      const wrap = ctx.run(first, () => {
-        const wrap = AsyncContext.wrap(() => {
+      const [wrap1, wrap2] = ctx.run(first, () => {
+        const wrap1 = AsyncContext.wrap(() => {
           assert.equal(ctx.get(), first);
+
           ctx.run(second, () => {
             assert.equal(ctx.get(), second);
           });
+
           assert.equal(ctx.get(), first);
         });
         assert.equal(ctx.get(), first);
-        return wrap;
+
+        ctx.run(second, () => {
+          assert.equal(ctx.get(), second);
+        });
+
+        const wrap2 = AsyncContext.wrap(() => {
+          assert.equal(ctx.get(), first);
+
+          ctx.run(second, () => {
+            assert.equal(ctx.get(), second);
+          });
+
+          assert.equal(ctx.get(), first);
+        });
+        assert.equal(ctx.get(), first);
+        return [wrap1, wrap2];
       });
 
-      wrap();
+      wrap1();
+      wrap2();
       assert.equal(ctx.get(), undefined);
     });
 
-    it("runs different context within wrap", () => {
+    test("runs within wrap", () => {
+      const ctx = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+
+      const [wrap1, wrap2] = ctx.run(first, () => {
+        const wrap1 = AsyncContext.wrap(() => {
+          assert.equal(ctx.get(), first);
+
+          ctx.run(second, () => {
+            assert.equal(ctx.get(), second);
+          });
+
+          assert.equal(ctx.get(), first);
+        });
+        assert.equal(ctx.get(), first);
+
+        ctx.run(second, () => {
+          assert.equal(ctx.get(), second);
+        });
+
+        const wrap2 = AsyncContext.wrap(() => {
+          assert.equal(ctx.get(), first);
+
+          ctx.run(second, () => {
+            assert.equal(ctx.get(), second);
+          });
+
+          assert.equal(ctx.get(), first);
+        });
+        assert.equal(ctx.get(), first);
+        return [wrap1, wrap2];
+      });
+
+      wrap1();
+      wrap2();
+      assert.equal(ctx.get(), undefined);
+    });
+
+    test("runs different context within wrap", () => {
       const a = new AsyncContext<Value>();
       const b = new AsyncContext<Value>();
       const first = { id: 1 };
       const second = { id: 2 };
 
-      const wrap = a.run(first, () => {
-        const wrap = AsyncContext.wrap(() => {
+      const [wrap1, wrap2] = a.run(first, () => {
+        const wrap1 = AsyncContext.wrap(() => {
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), undefined);
+
+          b.run(second, () => {
+            assert.equal(a.get(), first);
+            assert.equal(b.get(), second);
+          });
+
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), undefined);
+        });
+
+        a.run(second, () => {});
+
+        const wrap2 = AsyncContext.wrap(() => {
           assert.equal(a.get(), first);
           assert.equal(b.get(), undefined);
 
@@ -135,15 +232,62 @@ describe("sync", () => {
 
         assert.equal(a.get(), first);
         assert.equal(b.get(), undefined);
-        return wrap;
+        return [wrap1, wrap2];
       });
 
-      wrap();
+      wrap1();
+      wrap2();
       assert.equal(a.get(), undefined);
       assert.equal(b.get(), undefined);
     });
 
-    it("wrap within nesting contexts", () => {
+    test("runs different context within wrap, 2", () => {
+      const a = new AsyncContext<Value>();
+      const b = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+
+      const [wrap1, wrap2] = a.run(first, () => {
+        const wrap1 = AsyncContext.wrap(() => {
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), undefined);
+
+          b.run(second, () => {
+            assert.equal(a.get(), first);
+            assert.equal(b.get(), second);
+          });
+
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), undefined);
+        });
+
+        b.run(second, () => {});
+
+        const wrap2 = AsyncContext.wrap(() => {
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), undefined);
+
+          b.run(second, () => {
+            assert.equal(a.get(), first);
+            assert.equal(b.get(), second);
+          });
+
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), undefined);
+        });
+
+        assert.equal(a.get(), first);
+        assert.equal(b.get(), undefined);
+        return [wrap1, wrap2];
+      });
+
+      wrap1();
+      wrap2();
+      assert.equal(a.get(), undefined);
+      assert.equal(b.get(), undefined);
+    });
+
+    test("wrap within nesting contexts", () => {
       const ctx = new AsyncContext<Value>();
       const first = { id: 1 };
       const second = { id: 2 };
@@ -178,7 +322,7 @@ describe("sync", () => {
       assert.equal(ctx.get(), undefined);
     });
 
-    it("wrap within nesting different contexts", () => {
+    test("wrap within nesting different contexts", () => {
       const a = new AsyncContext<Value>();
       const b = new AsyncContext<Value>();
       const first = { id: 1 };
@@ -220,7 +364,7 @@ describe("sync", () => {
       assert.equal(b.get(), undefined);
     });
 
-    it("wrap within nesting different contexts, 2", () => {
+    test("wrap within nesting different contexts, 2", () => {
       const a = new AsyncContext<Value>();
       const b = new AsyncContext<Value>();
       const c = new AsyncContext<Value>();
@@ -258,7 +402,7 @@ describe("sync", () => {
       assert.equal(c.get(), undefined);
     });
 
-    it("wrap within nesting different contexts, 3", () => {
+    test("wrap within nesting different contexts, 3", () => {
       const a = new AsyncContext<Value>();
       const b = new AsyncContext<Value>();
       const c = new AsyncContext<Value>();
@@ -298,7 +442,7 @@ describe("sync", () => {
       assert.equal(c.get(), undefined);
     });
 
-    it("wrap within nesting different contexts, 4", () => {
+    test("wrap within nesting different contexts, 4", () => {
       const a = new AsyncContext<Value>();
       const b = new AsyncContext<Value>();
       const c = new AsyncContext<Value>();
@@ -338,7 +482,7 @@ describe("sync", () => {
       assert.equal(c.get(), undefined);
     });
 
-    it("wrap within nesting different contexts, 5", () => {
+    test("wrap within nesting different contexts, 5", () => {
       const a = new AsyncContext<Value>();
       const b = new AsyncContext<Value>();
       const c = new AsyncContext<Value>();
@@ -379,7 +523,7 @@ describe("sync", () => {
       assert.equal(c.get(), undefined);
     });
 
-    it("wrap within nesting different contexts, 6", () => {
+    test("wrap within nesting different contexts, 6", () => {
       const a = new AsyncContext<Value>();
       const b = new AsyncContext<Value>();
       const c = new AsyncContext<Value>();
@@ -420,7 +564,7 @@ describe("sync", () => {
       assert.equal(c.get(), undefined);
     });
 
-    it("wrap out of order", () => {
+    test("wrap out of order", () => {
       const ctx = new AsyncContext<Value>();
       const first = { id: 1 };
       const second = { id: 2 };

--- a/tests/async-context.test.ts
+++ b/tests/async-context.test.ts
@@ -1,5 +1,5 @@
 import { AsyncContext } from "../src/index";
-import assert from "node:assert/strict";
+import { strict as assert } from "assert";
 
 type Value = { id: number };
 

--- a/tests/async-context.test.ts
+++ b/tests/async-context.test.ts
@@ -231,7 +231,6 @@ describe("sync", () => {
       const wrap = a.run(first, () => {
         const wrap = b.run(second, () => {
           const wrap = c.run(third, () => {
-            debugger;
             return AsyncContext.wrap(() => {
               assert.equal(a.get(), first);
               assert.equal(b.get(), second);
@@ -272,7 +271,6 @@ describe("sync", () => {
           AsyncContext.wrap(() => {});
 
           const wrap = c.run(third, () => {
-            debugger;
             return AsyncContext.wrap(() => {
               assert.equal(a.get(), first);
               assert.equal(b.get(), second);
@@ -313,7 +311,6 @@ describe("sync", () => {
 
         const wrap = b.run(second, () => {
           const wrap = c.run(third, () => {
-            debugger;
             return AsyncContext.wrap(() => {
               assert.equal(a.get(), first);
               assert.equal(b.get(), second);

--- a/tests/async-context.test.ts
+++ b/tests/async-context.test.ts
@@ -26,9 +26,9 @@ describe("sync", () => {
       const ctx = new AsyncContext<Value>();
       const expected = { id: 1 };
 
-      const actual = ctx.run(expected, () => ctx.get());
-
-      assert.equal(actual, expected);
+      ctx.run(expected, () => {
+        assert.equal(ctx.get(), expected);
+      });
     });
 
     it("get within nesting contexts", () => {
@@ -36,11 +36,14 @@ describe("sync", () => {
       const first = { id: 1 };
       const second = { id: 2 };
 
-      const actual = ctx.run(first, () => {
-        return [ctx.get(), ctx.run(second, () => ctx.get()), ctx.get()];
+      ctx.run(first, () => {
+        assert.equal(ctx.get(), first);
+        ctx.run(second, () => {
+          assert.equal(ctx.get(), second);
+        });
+        assert.equal(ctx.get(), first);
       });
-
-      assert.deepStrictEqual(actual, [first, second, first]);
+      assert.equal(ctx.get(), undefined);
     });
 
     it("get within nesting different contexts", () => {
@@ -49,24 +52,18 @@ describe("sync", () => {
       const first = { id: 1 };
       const second = { id: 2 };
 
-      const actual = a.run(first, () => {
-        return [
-          a.get(),
-          b.get(),
-          ...b.run(second, () => [a.get(), b.get()]),
-          a.get(),
-          b.get(),
-        ];
+      a.run(first, () => {
+        assert.equal(a.get(), first);
+        assert.equal(b.get(), undefined);
+        b.run(second, () => {
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), second);
+        });
+        assert.equal(a.get(), first);
+        assert.equal(b.get(), undefined);
       });
-
-      assert.deepStrictEqual(actual, [
-        first,
-        undefined,
-        first,
-        second,
-        first,
-        undefined,
-      ]);
+      assert.equal(a.get(), undefined);
+      assert.equal(b.get(), undefined);
     });
   });
 
@@ -75,22 +72,24 @@ describe("sync", () => {
       const ctx = new AsyncContext<Value>();
       const wrapped = AsyncContext.wrap(() => ctx.get());
 
-      const actual = ctx.run({ id: 1 }, () => wrapped());
-
-      assert.equal(actual, undefined);
+      ctx.run({ id: 1 }, () => {
+        assert.equal(wrapped(), undefined);
+      });
     });
 
     it("stores current state", () => {
       const ctx = new AsyncContext<Value>();
       const expected = { id: 1 };
 
-      const wrapped = ctx.run(expected, () => {
-        return AsyncContext.wrap(() => ctx.get());
+      const wrap = ctx.run(expected, () => {
+        const wrap = AsyncContext.wrap(() => ctx.get());
+        assert.equal(wrap(), expected);
+        assert.equal(ctx.get(), expected);
+        return wrap;
       });
 
-      const actual = wrapped();
-
-      assert.equal(actual, expected);
+      assert.equal(wrap(), expected);
+      assert.equal(ctx.get(), undefined);
     });
 
     it("wrap within nesting contexts", () => {
@@ -98,15 +97,76 @@ describe("sync", () => {
       const first = { id: 1 };
       const second = { id: 2 };
 
-      const actual = ctx.run(first, () => {
-        const firstWrap = AsyncContext.wrap(() => ctx.get());
-        const secondWrap = ctx.run(second, () => {
-          return AsyncContext.wrap(() => ctx.get());
+      const [firstWrap, secondWrap] = ctx.run(first, () => {
+        const firstWrap = AsyncContext.wrap(() => {
+          assert.equal(ctx.get(), first);
         });
-        return [ctx.get(), firstWrap(), secondWrap(), ctx.get()];
+        firstWrap();
+
+        const secondWrap = ctx.run(second, () => {
+          const secondWrap = AsyncContext.wrap(() => {
+            firstWrap();
+            assert.equal(ctx.get(), second);
+          });
+          firstWrap();
+          secondWrap();
+          assert.equal(ctx.get(), second);
+
+          return secondWrap;
+        });
+
+        firstWrap();
+        secondWrap();
+        assert.equal(ctx.get(), first);
+
+        return [firstWrap, secondWrap];
       });
 
-      assert.deepStrictEqual(actual, [first, first, second, first]);
+      firstWrap();
+      secondWrap();
+      assert.equal(ctx.get(), undefined);
+    });
+
+    it("wrap within nesting different contexts", () => {
+      const a = new AsyncContext<Value>();
+      const b = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+
+      const [firstWrap, secondWrap] = a.run(first, () => {
+        const firstWrap = AsyncContext.wrap(() => {
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), undefined);
+        });
+        firstWrap();
+
+        const secondWrap = b.run(second, () => {
+          const secondWrap = AsyncContext.wrap(() => {
+            firstWrap();
+            assert.equal(a.get(), first);
+            assert.equal(b.get(), second);
+          });
+
+          firstWrap();
+          secondWrap();
+          assert.equal(a.get(), first);
+          assert.equal(b.get(), second);
+
+          return secondWrap;
+        });
+
+        firstWrap();
+        secondWrap();
+        assert.equal(a.get(), first);
+        assert.equal(b.get(), undefined);
+
+        return [firstWrap, secondWrap];
+      });
+
+      firstWrap();
+      secondWrap();
+      assert.equal(a.get(), undefined);
+      assert.equal(b.get(), undefined);
     });
 
     it("wrap out of order", () => {
@@ -115,14 +175,20 @@ describe("sync", () => {
       const second = { id: 2 };
 
       const firstWrap = ctx.run(first, () => {
-        return AsyncContext.wrap(() => ctx.get());
+        return AsyncContext.wrap(() => {
+          assert.equal(ctx.get(), first);
+        });
       });
       const secondWrap = ctx.run(second, () => {
-        return AsyncContext.wrap(() => ctx.get());
+        return AsyncContext.wrap(() => {
+          assert.equal(ctx.get(), second);
+        });
       });
-      const actual = [firstWrap(), secondWrap(), firstWrap(), secondWrap()];
 
-      assert.deepStrictEqual(actual, [first, second, first, second]);
+      firstWrap();
+      secondWrap();
+      firstWrap();
+      secondWrap();
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,6 @@
     "target": "esnext",
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "nodenext",
+    "noEmit": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "nodenext",
+  }
+}


### PR DESCRIPTION
Currently, every time `run()` is called, we clone the underlying storage `Map`. This is done so that the the modification will not change a map which is held by a `wrap`'s snapshot. I believe "wrapping" (either explicitly with `AsyncContext.wrap()` or implicitly through `Promise`s) will be performed 10000x more times in a normal program than `run()`, so I'm doing everything possible to make the `wrap()` method as fast as possible. Further, that `get()` will be called at least at much and probably more as `run()`. So my priorities are:

- `wrap()` **must be `O(1)`** (and ideally require nothing more than a pointer reference)
- `get()` should be as fast as possible
- `run()` may be slow, but let's try to make it fast

These priorities lead to code that causes quadratic cloning of the underlying `Map` as we add more keys in nesting `run()` calls. That's not ideal.

```js
// clones map with 0 keys
a.run(1, () => {
  // clones map with 1 key
  b.run(2, () => {
    // clones map with 2 keys
    c.run(3, () => {
      a.get();
      b.get();
      c.get();
    });
  });
});
```

We can fix this if we know whether a snapshot is held by anyone. If there is, then we must treat the `Map` as immutable (because someone has a direct access to it). If not, then we can directly mutate without worrying.

```js
// no clone, direct mutate
a.run(1, () => {
  // no clone, direct mutate
  b.run(2, () => {
    // no clone, direct mutate
    c.run(3, () => {
      a.get();
      b.get();
      c.get();
    });
  });
});
```

Because no wrapping was done (and there's no await/promises), we didn't have to clone anything.

There are some interesting cases with the new code. Once a snapshot has been taken, further mutations will clone the underlying `Map` and mutate that clone. This comes up when we enter a run from a frozen state, and when we exit a run that has taken a snapshot:

```js
// Entering this state will not clone
a.run(1, () => {
  // Entering this state will not clone
  b.run(2, () => {

    // Take a snapshot of the current { a: 1, b: 2 } state,
    // which will freeze the mappings.
    AsyncContext.wrap(cb);

    // Because the current state is frozen, entering this run will require
    // a clone to add the `c: 3` data.
    c.run(3, () => {
      // The state inside this run isn't frozen, it's a brand new clone of
      // the old state with the `c: 3` data.

      // Entering this run will not clone.
      d.run(4, () => {
        // Exiting this run will not clone.
      });

      // Exiting this run will not clone.
    });

    // We're back to the frozen { a: 1, b: 2 } state.
    
    // Because we're frozen, we cannot remove the `b: 2` data.
    // Exiting will cause a clone.
  });

  // We're back to the `{ a: 1 }` state.
  // This state isn't frozen.
 
  // Exiting this run will not clone.
});
```

We can prove that the new code clones less overall than the old code does. In the old code, every enter would clone. In the new code, we only clone:
- on enter if the current state is frozen
  - Meaning entering is no worse, and likely much better
- on exit if the the current state is frozen (the exit case is a littler harder to reason about)
  1. Current state is unfrozen before entering, and we snapshot the new state before exit:
     1. we did not clone to enter
     2. we freeze new state
     3. we clone on exit to remove the newly added key
     -  This is no worse than cloning to enter in the old code.
  2. Current state is frozen before entering, and we snapshot the new state before exit:
     1. we clone to enter
     2. we freeze new state
     3. we restore the old (known-frozen-at-start) state without modifying the current state
     -  The trick is the way we restore!
     -  Instead of trying to delete the newly added key, we just set the global state back to the old frozen state.

So, we're more optimal in all cases:

- `wrap()`: `O(1)`
  - allocate a struct with only a single pointer, which can optimize to a single pointer in memory
- `get()`: `O(1)`
  - just a `Map.p.get()`
- `run()`: `O(1)` (if not wrapped) or `O(n)` (if wrapped)
  - No worse than before, and sometimes better.

There are alternative algorithms using purely-functional immutable data structures, which trade make `run()` and `get()` operate at `O(1)` and `O(n)`, but I don't think that's optimal.